### PR TITLE
chore: bump latest version to 1.00.0-beta

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM openjdk:8-jre-alpine
 
 # Expose ports
-EXPOSE 8080
+EXPOSE 8484
 
 # Add tags
 LABEL \
@@ -26,7 +26,7 @@ RUN apk update  && \
   apk add curl bash && \
   rm -rf /var/cache/apk/* && \
   apk upgrade  && \
-  { [ "${COCKPIT_VERSION}" = "LATEST" ] && export DOWNLOAD_URL="${DOWNLOAD_URL}v0.26.0/download?job=release-product"; } || \
+  { [ "${COCKPIT_VERSION}" = "LATEST" ] && export DOWNLOAD_URL="${DOWNLOAD_URL}v1.00.0-beta/download?job=release-product"; } || \
   { [ "${COCKPIT_VERSION}" = "SNAPSHOT" ] && export DOWNLOAD_URL="${DOWNLOAD_URL}master/download?job=package-product-master"; } || \
   { export DOWNLOAD_URL="${DOWNLOAD_URL}${COCKPIT_VERSION}/download?job=release-product"; } && \
   echo "Downloading ${COCKPIT_VERSION}: ${DOWNLOAD_URL}" && \

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker ps
 docker logs petals-cockpit
 
 # Verify the ports used on the host (example)
-sudo lsof -i :8080
+sudo lsof -i :8484
 
 # Get information about the container
 docker inspect petals-cockpit
@@ -37,16 +37,16 @@ Versions match. As an example, to get Petals Cockpit 0.20.0, just type in `docke
 ## Run parameters
 
 When running Petals Cockpit by a docker image, a default administrator user is added automatically:
-* user: `admin`
 * username: `admin`
+* user: `admin`
 * password: `admin`
 
 It is possible to change this user with the following parameters: 
 
 | Argument | Optional | Default | Description |
 | -------- | :------: | :-----: | ----------- |
-| COCKPIT_USER | yes | `admin` | The user's id, also his login. |
-| COCKPIT_USERNAME | yes | `admin` | The name under which the user will appear. |
+| COCKPIT_USERNAME | yes | `admin` | The user's id, also his login. |
+| COCKPIT_NAME | yes | `admin` | The name under which the user will appear. |
 | COCKPIT_PASS | yes | `admin` | The user's password. |
 | COCKPIT_WORKSPACE | yes | - | The user's workspace. Which will be set as current workspace for the user.  **Beware, only compatible with version 0.22.0 or higher.** |
 
@@ -57,7 +57,7 @@ It is pretty straightforward :
 ```
 docker run \
 	-p 8080:8080 --name petals-cockpit \
-	-e COCKPIT_USER="user001" \
+	-e COCKPIT_USERNAME="user001" \
 	-e COCKPIT_NAME="myName" \
 	-e COCKPIT_PASS="myOwnPassword" \
 	-e COCKPIT_WORKSPACE="myWorkspace" \

--- a/docker-wrapper.sh
+++ b/docker-wrapper.sh
@@ -8,8 +8,8 @@ cp_user="admin"
 cp_name="admin"
 cp_pass="admin"
 
-[ ! -z "${COCKPIT_USER+x}" ] && cp_user="$COCKPIT_USER"
-[ ! -z "${COCKPIT_USERNAME+x}" ] && cp_name="$COCKPIT_USERNAME"
+[ ! -z "${COCKPIT_USERNAME+x}" ] && cp_user="$COCKPIT_USERNAME"
+[ ! -z "${COCKPIT_NAME+x}" ] && cp_name="$COCKPIT_NAME"
 [ ! -z "${COCKPIT_PASS+x}" ] && cp_pass="$COCKPIT_PASS"
 
 if [ ! -z "${COCKPIT_WORKSPACE+x}" ]


### PR DESCRIPTION
Use version 1.00.0-beta (also 0.27 and latest)
Modifiy and correct parameters names to add an user